### PR TITLE
Update PickFolder.go

### DIFF
--- a/_examples/notusingutil/PickFolder.go
+++ b/_examples/notusingutil/PickFolder.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	pickFolderDialog, err := cfd.NewOpenFileDialog(cfd.DialogConfig{
+	pickFolderDialog, err := cfd.NewSelectFolderDialog(cfd.DialogConfig{
 		Title: "Pick Folder",
 		Role:  "PickFolderExample",
 	})


### PR DESCRIPTION
corrected function call in folder example (go-common-file-dialog/_examples/notusingutil/PickFolder.go /) to use folder pick function instead of file pick function